### PR TITLE
Add Crossplane BCP scaffolding

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+stages:
+  - build
+  - push
+
+variables:
+  DEV_REGISTRY: "registry.example.com/dev"
+
+build_packages:
+  stage: build
+  image: crossplane/crossplane-cli:latest
+  script:
+    - crossplane xpkg build --name config-bundle.xpkg crossplane-bcp/config-bundle
+    - crossplane xpkg build --name function-object-reader.xpkg crossplane-bcp/functions/object-reader
+    - crossplane xpkg build --name function-git-reader.xpkg crossplane-bcp/functions/git-reader
+  artifacts:
+    paths:
+      - config-bundle.xpkg
+      - function-object-reader.xpkg
+      - function-git-reader.xpkg
+
+push_packages:
+  stage: push
+  image: crossplane/crossplane-cli:latest
+  script:
+    - crossplane xpkg push config-bundle.xpkg ${DEV_REGISTRY}/bcp-config-bundle:latest
+    - crossplane xpkg push function-object-reader.xpkg ${DEV_REGISTRY}/function-object-reader:latest
+    - crossplane xpkg push function-git-reader.xpkg ${DEV_REGISTRY}/function-git-reader:latest

--- a/crossplane-bcp/README.md
+++ b/crossplane-bcp/README.md
@@ -1,0 +1,23 @@
+# Crossplane BCP Deployment
+
+This directory contains the files and folder structure for deploying the Base Cluster Platform (BCP) and JCP clusters using Crossplane. The flow follows the diagrams provided and uses a GitLab CI pipeline to build and push Crossplane packages.
+
+```
+crossplane-bcp/
+├── build/
+│   ├── providerConfigs/      # Crossplane provider and provider configs
+│   └── services/             # Configuration services bundled as xpkg
+├── config-bundle/            # Bundle combining services and providers
+├── functions/
+│   ├── git-reader/           # Function package to read Git repos
+│   └── object-reader/        # Function package to read cluster objects
+├── helm/
+│   ├── helm-base/            # Base Helm chart
+│   └── helm-jcrs-jcp/        # Helm chart for JCRS/JCP
+├── clusters/
+│   ├── bcp/                  # Manifests to install BCP cluster
+│   └── jcp/                  # Manifests to install JCP cluster
+└── README.md
+```
+
+The `.gitlab-ci.yml` file in the repo root builds these packages and pushes them to the OCI registry defined by `DEV_REGISTRY`.

--- a/crossplane-bcp/build/providerConfigs/provider.yaml
+++ b/crossplane-bcp/build/providerConfigs/provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-helm
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v0.15.0
+---
+apiVersion: helm.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: helm-default
+spec:
+  credentials:
+    source: InjectedIdentity

--- a/crossplane-bcp/build/services/service.yaml
+++ b/crossplane-bcp/build/services/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: bcp-services
+spec:
+  crossplane:
+    version: ">=v1.13.0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-helm
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-kubernetes

--- a/crossplane-bcp/clusters/bcp/crossplane.yaml
+++ b/crossplane-bcp/clusters/bcp/crossplane.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: bcp
+spec:
+  package: ${DEV_REGISTRY}/bcp-config-bundle:latest

--- a/crossplane-bcp/clusters/jcp/crossplane.yaml
+++ b/crossplane-bcp/clusters/jcp/crossplane.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: jcp
+spec:
+  package: ${DEV_REGISTRY}/jcp-config-bundle:latest

--- a/crossplane-bcp/config-bundle/bundle.yaml
+++ b/crossplane-bcp/config-bundle/bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: bcp-config-bundle
+spec:
+  dependsOn:
+    - configuration: xpkg.upbound.io/example/bcp-services
+  crossplane:
+    version: ">=v1.13.0"

--- a/crossplane-bcp/functions/git-reader/function.yaml
+++ b/crossplane-bcp/functions/git-reader/function.yaml
@@ -1,0 +1,6 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-git-reader
+spec:
+  image: xpkg.upbound.io/crossplane-contrib/function-git:v0.2.0

--- a/crossplane-bcp/functions/object-reader/function.yaml
+++ b/crossplane-bcp/functions/object-reader/function.yaml
@@ -1,0 +1,6 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-object-reader
+spec:
+  image: xpkg.upbound.io/crossplane-contrib/function-go-runner:v0.4.0

--- a/crossplane-bcp/helm/helm-base/Chart.yaml
+++ b/crossplane-bcp/helm/helm-base/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: helm-base
+description: Base Helm chart for BCP deployment
+version: 0.1.0

--- a/crossplane-bcp/helm/helm-jcrs-jcp/Chart.yaml
+++ b/crossplane-bcp/helm/helm-jcrs-jcp/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: helm-jcrs-jcp
+description: Helm chart for JCRS and JCP components
+version: 0.1.0


### PR DESCRIPTION
## Summary
- add a `crossplane-bcp` directory with sample provider config, services, functions and charts
- describe the folder layout in a new README
- add a `.gitlab-ci.yml` pipeline to build and push Crossplane packages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841998dfb7c832fbdffebcac5f53c2e