### PR TITLE
Add more BCP/JCP tooling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,67 @@
+stages:
+  - build
+  - push
+  - destroy
+
+variables:
+  DEV_REGISTRY: "registry.example.com/dev"
+
+build_xpkgs:
+  stage: build
+  image: crossplane/crossplane-cli:latest
+  script:
+    - crossplane xpkg build --name provider-configs.xpkg crossplane-bcp/build/providerConfigs
+    - crossplane xpkg build --name services.xpkg crossplane-bcp/build/services
+    - crossplane xpkg build --name config-bundle.xpkg crossplane-bcp/config-bundle
+    - crossplane xpkg build --name jcp-config-bundle.xpkg crossplane-bcp/jcp-config-bundle
+    - crossplane xpkg build --name function-object-reader.xpkg crossplane-bcp/functions/object-reader
+    - crossplane xpkg build --name function-git-reader.xpkg crossplane-bcp/functions/git-reader
+  artifacts:
+    paths:
+      - provider-configs.xpkg
+      - services.xpkg
+      - config-bundle.xpkg
+      - jcp-config-bundle.xpkg
+      - function-object-reader.xpkg
+      - function-git-reader.xpkg
+
+build_helm:
+  stage: build
+  image: alpine/helm:3.8.2
+  script:
+    - helm package crossplane-bcp/helm/helm-base
+    - helm package crossplane-bcp/helm/helm-jcrs-jcp
+  artifacts:
+    paths:
+      - helm-base-0.1.0.tgz
+      - helm-jcrs-jcp-0.1.0.tgz
+
+push_xpkgs:
+  stage: push
+  image: crossplane/crossplane-cli:latest
+  script:
+    - crossplane xpkg push provider-configs.xpkg ${DEV_REGISTRY}/provider-configs:latest
+    - crossplane xpkg push services.xpkg ${DEV_REGISTRY}/bcp-services:latest
+    - crossplane xpkg push config-bundle.xpkg ${DEV_REGISTRY}/bcp-config-bundle:latest
+    - crossplane xpkg push jcp-config-bundle.xpkg ${DEV_REGISTRY}/jcp-config-bundle:latest
+    - crossplane xpkg push function-object-reader.xpkg ${DEV_REGISTRY}/function-object-reader:latest
+    - crossplane xpkg push function-git-reader.xpkg ${DEV_REGISTRY}/function-git-reader:latest
+
+push_helm:
+  stage: push
+  image: alpine/helm:3.8.2
+  script:
+    - helm push helm-base-0.1.0.tgz oci://${DEV_REGISTRY}
+    - helm push helm-jcrs-jcp-0.1.0.tgz oci://${DEV_REGISTRY}
+
+destroy_bcp:
+  stage: destroy
+  script:
+    - crossplane xpkg yank ${DEV_REGISTRY}/bcp-config-bundle:latest || true
+    - ./crossplane-bcp/scripts/destroy_bcp.sh
+
+destroy_jcp:
+  stage: destroy
+  script:
+    - crossplane xpkg yank ${DEV_REGISTRY}/jcp-config-bundle:latest || true
+    - ./crossplane-bcp/scripts/destroy_jcp.sh

--- a/crossplane-bcp/ARCHITECTURE.md
+++ b/crossplane-bcp/ARCHITECTURE.md
@@ -1,0 +1,31 @@
+# Control Plane Architecture
+
+This document summarizes the architecture principles referenced in the BCP/JCP deployment flowcharts. It focuses on how execution environments and trust zones interact within the control plane.
+
+## Overview
+The control plane (CP) orchestrates the provisioning of Execution Environments (EEs) and their Trust Zones (TZs). It also manages networking, RBAC and infrastructure lifecycles using Crossplane.
+
+## Objectives
+The JCWA Next-Gen Reference Design (JNeRD) aims to provide:
+
+- **Multi‑tenant** infrastructure to support many organizations
+- **Multi‑cloud and on‑prem** deployments
+- **Self‑service** provisioning with minimal manual intervention
+
+## Execution Environments
+Each EE corresponds to a distinct mission or organization. Within an EE, multiple Trust Zones can be created on demand for teams or projects. Shared and Managed TZs are created automatically for shared services and managed JCP workloads.
+
+## Trust Zones
+Every TZ has its own network and RBAC boundaries. Networks connect transparently but traffic is controlled by policies. Project TZs are created as needed to isolate workloads for teams.
+
+## Control Planes
+The Base Control Plane (BCP) is a single‑node installation used to bootstrap the first JCP in air‑gapped environments. The Joint Control Plane (JCP) then manages downstream EEs and all of the resources described above.
+
+### BCP Responsibilities
+- Build and push Crossplane packages and Helm charts to an internal registry.
+- Deploy an EKS cluster using Crossplane compositions.
+- Install ArgoCD which deploys Keycloak, Backstage, Netbox and other services.
+
+### JCP Responsibilities
+- Provision workload EKS clusters via Crossplane.
+- Manage application deployments via ArgoCD with charts stored in Harbor.

--- a/crossplane-bcp/README.md
+++ b/crossplane-bcp/README.md
@@ -1,0 +1,31 @@
+# Crossplane BCP Deployment
+
+This directory houses the resources required to build and deploy the Base Control Plane (BCP) and the downstream JCP using Crossplane. The folder structure mirrors the flow diagrams described in the architecture documentation.
+
+```
+crossplane-bcp/
+├── ARCHITECTURE.md           # High level architecture overview
+├── build/
+│   ├── providerConfigs/      # Crossplane providers and configs
+│   └── services/             # Compositions and Helm releases
+│       └── compositions/     # EKS cluster definition and composition
+├── config-bundle/            # Bundle combining services and providers
+├── jcp-config-bundle/        # Bundle for the JCP installation
+├── functions/
+│   ├── git-reader/           # Function package to read Git repos
+│   └── object-reader/        # Function package to read cluster objects
+├── helm/
+│   ├── helm-base/            # Base Helm chart
+│   └── helm-jcrs-jcp/        # Helm chart for JCRS/JCP workloads
+├── scripts/                  # Teardown helpers
+├── clusters/
+│   ├── bcp/                  # Manifests to install the BCP
+│   └── jcp/                  # Manifests to install the JCP
+```
+
+## GitLab CI Pipeline
+The root `.gitlab-ci.yml` builds Crossplane packages and Helm charts and pushes them to the registry defined by `DEV_REGISTRY`. These packages are then pulled and deployed by the CLI as shown in the flowcharts.
+
+Optional `destroy_bcp` and `destroy_jcp` jobs call scripts in `scripts/` to tear down clusters when scheduled.
+
+Refer to [ARCHITECTURE.md](ARCHITECTURE.md) for more background on execution environments, trust zones and control plane concepts.

--- a/crossplane-bcp/build/providerConfigs/provider.yaml
+++ b/crossplane-bcp/build/providerConfigs/provider.yaml
@@ -1,0 +1,86 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-helm
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v0.15.0
+---
+apiVersion: helm.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: helm-default
+spec:
+  credentials:
+    source: InjectedIdentity
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.9.0
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: kubernetes-default
+spec:
+  credentials:
+    source: InjectedIdentity
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws:v0.36.0
+---
+apiVersion: aws.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: aws-default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-creds
+      key: creds
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-oci:v0.2.0
+---
+apiVersion: oci.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: oci-default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: oci-creds
+      key: creds
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-git
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-git:v0.1.0
+---
+apiVersion: git.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: git-default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: git-creds
+      key: creds

--- a/crossplane-bcp/build/services/argocd-bootstrap.yaml
+++ b/crossplane-bcp/build/services/argocd-bootstrap.yaml
@@ -1,0 +1,12 @@
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: argocd
+spec:
+  forProvider:
+    chart: argo-cd
+    repository: https://argoproj.github.io/argo-helm
+    version: 5.46.7
+    namespace: argocd
+  providerConfigRef:
+    name: helm-default

--- a/crossplane-bcp/build/services/cilium-helm.yaml
+++ b/crossplane-bcp/build/services/cilium-helm.yaml
@@ -1,0 +1,12 @@
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: cilium
+spec:
+  forProvider:
+    chart: cilium
+    repository: https://helm.cilium.io/
+    version: 1.14.6
+    namespace: kube-system
+  providerConfigRef:
+    name: helm-default

--- a/crossplane-bcp/build/services/compositions/cluster-definition.yaml
+++ b/crossplane-bcp/build/services/compositions/cluster-definition.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xclusters.compute.jne.rd
+spec:
+  group: compute.jne.rd
+  names:
+    kind: XCluster
+    plural: xclusters
+  claimNames:
+    kind: ClusterClaim
+    plural: clusterclaims
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    region:
+                      type: string
+                    version:
+                      type: string

--- a/crossplane-bcp/build/services/compositions/eks-composition.yaml
+++ b/crossplane-bcp/build/services/compositions/eks-composition.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: eks-cluster
+  labels:
+    provider: aws
+spec:
+  compositeTypeRef:
+    apiVersion: compute.jne.rd/v1alpha1
+    kind: XCluster
+  resources:
+    - name: eks
+      base:
+        apiVersion: eks.aws.upbound.io/v1beta1
+        kind: Cluster
+        spec:
+          forProvider:
+            region: us-east-1
+            version: "1.29"
+            roleArn: example
+            resourcesVpcConfig:
+              endpointPublicAccess: true
+      patches:
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.version
+          toFieldPath: spec.forProvider.version

--- a/crossplane-bcp/build/services/gitea-setup.yaml
+++ b/crossplane-bcp/build/services/gitea-setup.yaml
@@ -1,0 +1,12 @@
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: gitea
+spec:
+  forProvider:
+    chart: gitea
+    repository: https://dl.gitea.io/charts/
+    version: 10.1.0
+    namespace: gitea
+  providerConfigRef:
+    name: helm-default

--- a/crossplane-bcp/build/services/harbor-helm.yaml
+++ b/crossplane-bcp/build/services/harbor-helm.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: harbor
+spec:
+  forProvider:
+    chart: harbor
+    repository: https://helm.goharbor.io
+    version: 1.14.0
+    namespace: harbor
+    values:
+      expose:
+        type: clusterIP
+  providerConfigRef:
+    name: helm-default

--- a/crossplane-bcp/build/services/jcp-apps.yaml
+++ b/crossplane-bcp/build/services/jcp-apps.yaml
@@ -1,0 +1,11 @@
+apiVersion: argocd.crossplane.io/v1alpha1
+kind: Application
+metadata:
+  name: jcp-apps
+spec:
+  forProvider:
+    sourceRepoURL: https://example.com/git/jcp-manifests
+    path: apps
+    targetRevision: HEAD
+  providerConfigRef:
+    name: git-default

--- a/crossplane-bcp/build/services/service.yaml
+++ b/crossplane-bcp/build/services/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: bcp-services
+spec:
+  crossplane:
+    version: ">=v1.13.0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-helm
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
+    - provider: xpkg.upbound.io/upbound/provider-aws
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-oci
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-git

--- a/crossplane-bcp/clusters/bcp/crossplane.yaml
+++ b/crossplane-bcp/clusters/bcp/crossplane.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: bcp
+spec:
+  package: ${DEV_REGISTRY}/bcp-config-bundle:latest

--- a/crossplane-bcp/clusters/jcp/crossplane.yaml
+++ b/crossplane-bcp/clusters/jcp/crossplane.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: jcp
+spec:
+  package: ${DEV_REGISTRY}/jcp-config-bundle:latest

--- a/crossplane-bcp/config-bundle/bundle.yaml
+++ b/crossplane-bcp/config-bundle/bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: bcp-config-bundle
+spec:
+  dependsOn:
+    - configuration: xpkg.upbound.io/example/bcp-services
+  crossplane:
+    version: ">=v1.13.0"

--- a/crossplane-bcp/functions/git-reader/function.yaml
+++ b/crossplane-bcp/functions/git-reader/function.yaml
@@ -1,0 +1,6 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-git-reader
+spec:
+  image: xpkg.upbound.io/crossplane-contrib/function-git:v0.2.0

--- a/crossplane-bcp/functions/object-reader/function.yaml
+++ b/crossplane-bcp/functions/object-reader/function.yaml
@@ -1,0 +1,6 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-object-reader
+spec:
+  image: xpkg.upbound.io/crossplane-contrib/function-go-runner:v0.4.0

--- a/crossplane-bcp/helm/helm-base/Chart.yaml
+++ b/crossplane-bcp/helm/helm-base/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: helm-base
+description: Base Helm chart for BCP deployment
+version: 0.1.0

--- a/crossplane-bcp/helm/helm-base/values.yaml
+++ b/crossplane-bcp/helm/helm-base/values.yaml
@@ -1,0 +1,1 @@
+registry: registry.example.com/dev

--- a/crossplane-bcp/helm/helm-jcrs-jcp/Chart.yaml
+++ b/crossplane-bcp/helm/helm-jcrs-jcp/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: helm-jcrs-jcp
+description: Helm chart for JCRS and JCP components
+version: 0.1.0

--- a/crossplane-bcp/helm/helm-jcrs-jcp/values.yaml
+++ b/crossplane-bcp/helm/helm-jcrs-jcp/values.yaml
@@ -1,0 +1,11 @@
+argocd:
+  server:
+    extraArgs: ["--insecure"]
+keycloak:
+  replicaCount: 1
+netbox:
+  replicaCount: 1
+backstage:
+  replicaCount: 1
+certManager:
+  installCRDs: true

--- a/crossplane-bcp/jcp-config-bundle/bundle.yaml
+++ b/crossplane-bcp/jcp-config-bundle/bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: jcp-config-bundle
+spec:
+  dependsOn:
+    - configuration: xpkg.upbound.io/example/bcp-services
+  crossplane:
+    version: ">=v1.13.0"

--- a/crossplane-bcp/scripts/destroy_bcp.sh
+++ b/crossplane-bcp/scripts/destroy_bcp.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Teardown BCP cluster resources
+kubectl delete configuration jcp --ignore-not-found
+kubectl delete configuration bcp --ignore-not-found

--- a/crossplane-bcp/scripts/destroy_jcp.sh
+++ b/crossplane-bcp/scripts/destroy_jcp.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Teardown JCP cluster resources
+kubectl delete configuration jcp --ignore-not-found


### PR DESCRIPTION
## Summary
- extend provider configurations to include AWS, OCI and Git providers
- create compositions and Helm releases for deploying EKS and base services
- add JCP bundle, Helm chart values and ArgoCD bootstrap
- provide teardown scripts with CI jobs
- document updated folder structure and responsibilities

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841998dfb7c832fbdffebcac5f53c2e