### PR TITLE
Fix destroy stage image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,12 +62,14 @@ push_helm:
 
 destroy_bcp:
   stage: destroy
+  image: crossplane/crossplane-cli:latest
   script:
     - crossplane xpkg yank ${DEV_REGISTRY}/bcp-config-bundle:latest || true
     - ./crossplane-bcp/scripts/destroy_bcp.sh
 
 destroy_jcp:
   stage: destroy
+  image: crossplane/crossplane-cli:latest
   script:
     - crossplane xpkg yank ${DEV_REGISTRY}/jcp-config-bundle:latest || true
     - ./crossplane-bcp/scripts/destroy_jcp.sh


### PR DESCRIPTION
## Summary
- use Crossplane CLI image for `destroy_bcp`
- use Crossplane CLI image for `destroy_jcp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68434bc761c0832fa458ce51bd47b0fb