### PR TITLE
Add deploy stage to GitLab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,12 @@
 stages:
   - build
   - push
+  - deploy
   - destroy
 
 variables:
   DEV_REGISTRY: "registry.example.com/dev"
+  KUBECONFIG: "$CI_PROJECT_DIR/kubeconfig"
 
 build_xpkgs:
   stage: build
@@ -84,3 +86,19 @@ push_packages:
     - crossplane xpkg push config-bundle.xpkg ${DEV_REGISTRY}/bcp-config-bundle:latest
     - crossplane xpkg push function-object-reader.xpkg ${DEV_REGISTRY}/function-object-reader:latest
     - crossplane xpkg push function-git-reader.xpkg ${DEV_REGISTRY}/function-git-reader:latest
+
+deploy_bcp:
+  stage: deploy
+  image: bitnami/kubectl:latest
+  script:
+    - echo "$KUBECONFIG_DATA" > ${KUBECONFIG}
+    - envsubst < crossplane-bcp/clusters/bcp/crossplane.yaml | kubectl apply -f -
+
+deploy_jcp:
+  stage: deploy
+  image: bitnami/kubectl:latest
+  needs: ["deploy_bcp"]
+  script:
+    - echo "$KUBECONFIG_DATA" > ${KUBECONFIG}
+    - envsubst < crossplane-bcp/clusters/jcp/crossplane.yaml | kubectl apply -f -
+

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ packer-win10_1909.json - Packer definitions for building Windows images
 ```
 
 Refer to `crossplane-bcp/README.md` for detailed instructions on deploying the BCP and JCP using Crossplane. The original blog post on automating WVD with Azure DevOps can be found [here](https://bit.ly/2Qj8kfe).
+
+## Running the Pipeline
+
+The `.gitlab-ci.yml` pipeline builds, pushes and now deploys the Crossplane configuration. To execute the pipeline end-to-end:
+
+1. Set `DEV_REGISTRY` to the container registry where packages should be pushed.
+2. Provide a `KUBECONFIG_DATA` variable in GitLab CI containing credentials for the target Kubernetes cluster.
+3. Trigger the pipeline. After the push stage completes, the `deploy_bcp` and `deploy_jcp` jobs apply the manifests under `crossplane-bcp/clusters/` using `kubectl`.
+

--- a/crossplane-bcp/README.md
+++ b/crossplane-bcp/README.md
@@ -28,5 +28,8 @@ crossplane-bcp/
 The `.gitlab-ci.yml` file at the repo root packages these resources and pushes them to the container registry specified by `DEV_REGISTRY`.
 Optional jobs invoke the scripts in `scripts/` to destroy the BCP or JCP clusters when scheduled.
 
+The pipeline also contains a `deploy` stage. `deploy_bcp` installs the Base Control Plane by applying `clusters/bcp/crossplane.yaml`, then `deploy_jcp` installs the JCP using the manifests under `clusters/jcp/`. These jobs require the `KUBECONFIG_DATA` variable to be set with credentials for the target Kubernetes cluster.
+
 See [ARCHITECTURE.md](ARCHITECTURE.md) for additional details about execution environments and trust zones.
+
 


### PR DESCRIPTION
## Summary
- add a deploy stage after push in `.gitlab-ci.yml`
- deploy crossplane manifests for BCP and JCP via kubectl
- document new stage and credentials in README files

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68435c243db8832fb2073a24fcec2407