### PR TITLE
Add NodeGroup sizing

### DIFF
--- a/crossplane-bcp/ARCHITECTURE.md
+++ b/crossplane-bcp/ARCHITECTURE.md
@@ -29,3 +29,8 @@ The Base Control Plane (BCP) is a single‑node installation used to bootstrap t
 ### JCP Responsibilities
 - Provision workload EKS clusters via Crossplane.
 - Manage application deployments via ArgoCD with charts stored in Harbor.
+
+### Recommended NodeGroup Sizes
+
+- **BCP NodeGroup:** `t3.medium` instances with 50Gi disks.
+- **JCP NodeGroup:** `t3.large` instances with 100Gi disks and a desired size of three nodes to run ArgoCD, Harbor and Keycloak workloads.

--- a/crossplane-bcp/build/services/compositions/eks-composition.yaml
+++ b/crossplane-bcp/build/services/compositions/eks-composition.yaml
@@ -25,22 +25,45 @@ spec:
           toFieldPath: spec.forProvider.region
         - fromFieldPath: spec.parameters.version
           toFieldPath: spec.forProvider.version
-    - name: nodegroup
-      base:
-        apiVersion: eks.aws.upbound.io/v1beta1
-        kind: NodeGroup
-        spec:
-          forProvider:
-            region: us-east-1
-            clusterNameSelector:
-              matchControllerRef: true
-            nodeRoleArn: example
-            subnetIds:
-              - subnet-example
-            scalingConfig:
-              desiredSize: 2
-              maxSize: 2
-              minSize: 1
-      patches:
-        - fromFieldPath: spec.parameters.region
-          toFieldPath: spec.forProvider.region
+      - name: nodegroup
+        base:
+          apiVersion: eks.aws.upbound.io/v1beta1
+          kind: NodeGroup
+          spec:
+            forProvider:
+              region: us-east-1
+              clusterNameSelector:
+                matchControllerRef: true
+              nodeRoleArn: example
+              subnetIds:
+                - subnet-example
+              instanceType: t3.medium
+              diskSize: 50
+              scalingConfig:
+                desiredSize: 2
+                maxSize: 2
+                minSize: 1
+        patches:
+          - fromFieldPath: spec.parameters.region
+            toFieldPath: spec.forProvider.region
+      - name: jcp-nodegroup
+        base:
+          apiVersion: eks.aws.upbound.io/v1beta1
+          kind: NodeGroup
+          spec:
+            forProvider:
+              region: us-east-1
+              clusterNameSelector:
+                matchControllerRef: true
+              nodeRoleArn: example
+              subnetIds:
+                - subnet-example
+              instanceType: t3.large
+              diskSize: 100
+              scalingConfig:
+                desiredSize: 3
+                maxSize: 5
+                minSize: 1
+        patches:
+          - fromFieldPath: spec.parameters.region
+            toFieldPath: spec.forProvider.region


### PR DESCRIPTION
## Summary
- size BCP nodegroup in eks composition
- add JCP nodegroup for workloads
- document NodeGroup sizing guidance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68471f32439c832f8fbd7a0fd2fef247