### PR TITLE
Fix destroy_jcp job in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,9 +75,6 @@ destroy_jcp:
   script:
     - crossplane xpkg yank ${DEV_REGISTRY}/jcp-config-bundle:latest || true
     - ./crossplane-bcp/scripts/destroy_jcp.sh
-      - config-bundle.xpkg
-      - function-object-reader.xpkg
-      - function-git-reader.xpkg
 
 push_packages:
   stage: push


### PR DESCRIPTION
## Summary
- streamline the `destroy_jcp` job so only the destroy script runs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68471f3ca9c8832f8b4f9b0d9acac02a