### PR TITLE
Parameterize EKS composition

### DIFF
--- a/crossplane-bcp/build/services/compositions/cluster-definition.yaml
+++ b/crossplane-bcp/build/services/compositions/cluster-definition.yaml
@@ -28,6 +28,14 @@ spec:
                         type: string
                       version:
                         type: string
+                      instanceType:
+                        type: string
+                      diskSize:
+                        type: integer
+                      jcpInstanceType:
+                        type: string
+                      jcpDiskSize:
+                        type: integer
                     required:
                       - region
                       - version

--- a/crossplane-bcp/build/services/compositions/eks-composition.yaml
+++ b/crossplane-bcp/build/services/compositions/eks-composition.yaml
@@ -17,7 +17,7 @@ spec:
           forProvider:
             region: us-east-1
             version: "1.29"
-            roleArn: example
+            roleArn: example # TODO: replace with your IAM role ARN
             resourcesVpcConfig:
               endpointPublicAccess: true
         patches:
@@ -34,11 +34,11 @@ spec:
             region: us-east-1
             clusterNameSelector:
               matchControllerRef: true
-            nodeRoleArn: example
+            nodeRoleArn: example # TODO: replace with the node group role ARN
             subnetIds:
-              - subnet-example
-            instanceType: t3.medium
-            diskSize: 50
+              - subnet-example # TODO: update with actual subnet IDs
+            instanceType: t3.medium # default instance type
+            diskSize: 50            # default disk size in GiB
             scalingConfig:
               desiredSize: 2
               maxSize: 2
@@ -46,6 +46,10 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.instanceType
+          toFieldPath: spec.forProvider.instanceType
+        - fromFieldPath: spec.parameters.diskSize
+          toFieldPath: spec.forProvider.diskSize
     - name: jcp-nodegroup
       base:
         apiVersion: eks.aws.upbound.io/v1beta1
@@ -55,11 +59,11 @@ spec:
             region: us-east-1
             clusterNameSelector:
               matchControllerRef: true
-            nodeRoleArn: example
+            nodeRoleArn: example # TODO: replace with the node group role ARN
             subnetIds:
-              - subnet-example
-            instanceType: t3.large
-            diskSize: 100
+              - subnet-example # TODO: update with actual subnet IDs
+            instanceType: t3.large # default instance type for JCP
+            diskSize: 100          # default disk size in GiB
             scalingConfig:
               desiredSize: 3
               maxSize: 5
@@ -67,3 +71,7 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.jcpInstanceType
+          toFieldPath: spec.forProvider.instanceType
+        - fromFieldPath: spec.parameters.jcpDiskSize
+          toFieldPath: spec.forProvider.diskSize


### PR DESCRIPTION
## Summary
- define instance and disk parameters for BCP/JCP node groups
- allow patching these fields from `spec.parameters`
- note IAM role and subnet placeholders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849901c8224832f9a49df3fafc519b7