### PR TITLE
Update kubeconfig docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Refer to `crossplane-bcp/README.md` for detailed instructions on deploying the B
 The `.gitlab-ci.yml` pipeline builds, pushes and now deploys the Crossplane configuration. To execute the pipeline end-to-end:
 
 1. Set `DEV_REGISTRY` to the container registry where packages should be pushed. The default value in `.gitlab-ci.yml` is `registry.example.com/dev`, but you must replace this with the URL of your actual registry (GitLab registry, ECR, etc.) for the push stage to succeed.
-2. Provide a `KUBECONFIG_DATA` variable in GitLab CI containing credentials for the target Kubernetes cluster.
-3. Trigger the pipeline. After the push stage completes, the `deploy_bcp` and `deploy_jcp` jobs apply the manifests under `crossplane-bcp/clusters/` using `kubectl`.
+2. Extract the kubeconfig for the target cluster using `aws eks update-kubeconfig --name <cluster>` (or your provider's command) and store its contents in GitLab as `KUBECONFIG_DATA`.
+3. Ensure Crossplane is installed on the cluster referenced by `KUBECONFIG_DATA`.
+4. Trigger the pipeline. After the push stage completes, the `deploy_bcp` and `deploy_jcp` jobs apply the manifests under `crossplane-bcp/clusters/` using `kubectl`.
 
 
 ### Extracting the kubeconfig

--- a/crossplane-bcp/README.md
+++ b/crossplane-bcp/README.md
@@ -28,7 +28,7 @@ crossplane-bcp/
 The `.gitlab-ci.yml` file at the repo root packages these resources and pushes them to the container registry specified by `DEV_REGISTRY`.
 Optional jobs invoke the scripts in `scripts/` to destroy the BCP or JCP clusters when scheduled.
 
-The pipeline also contains a `deploy` stage. `deploy_bcp` installs the Base Control Plane by applying `clusters/bcp/crossplane.yaml`, then `deploy_jcp` installs the JCP using the manifests under `clusters/jcp/`. These jobs require the `KUBECONFIG_DATA` variable to be set with credentials for the target Kubernetes cluster.
+The pipeline also contains a `deploy` stage. `deploy_bcp` installs the Base Control Plane by applying `clusters/bcp/crossplane.yaml`, then `deploy_jcp` installs the JCP using the manifests under `clusters/jcp/`. These jobs require the `KUBECONFIG_DATA` variable to be set with credentials for the target Kubernetes cluster. Ensure Crossplane is already installed on that cluster.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for additional details about execution environments and trust zones.
 
@@ -36,7 +36,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for additional details about execution en
 
 ### Extracting the kubeconfig
 
-Use your cloud provider's CLI to fetch credentials and create a kubeconfig file. Example commands include:
+Use your cloud provider's CLI, for example `aws eks update-kubeconfig --name <cluster>`, to fetch credentials and create a kubeconfig file.
 
 ```bash
 aws eks update-kubeconfig --name <cluster>


### PR DESCRIPTION
## Summary
- detail how to retrieve kubeconfig and store it in GitLab CI
- note that the target cluster must already have Crossplane installed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684990d4058c832fb85a8b1402c81aaa