### PR TITLE
Add kubeconfig retrieval guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Refer to `crossplane-bcp/README.md` for detailed instructions on deploying the B
 The `.gitlab-ci.yml` pipeline builds, pushes and now deploys the Crossplane configuration. To execute the pipeline end-to-end:
 
 1. Set `DEV_REGISTRY` to the container registry where packages should be pushed. The default value in `.gitlab-ci.yml` is `registry.example.com/dev`, but you must replace this with the URL of your actual registry (GitLab registry, ECR, etc.) for the push stage to succeed.
-2. Extract the kubeconfig for the target cluster using `aws eks update-kubeconfig --name <cluster>` (or your provider's command) and store its contents in GitLab as `KUBECONFIG_DATA`.
-3. Ensure Crossplane is installed on the cluster referenced by `KUBECONFIG_DATA`.
+2. Retrieve the kubeconfig for the **target** cluster using `aws eks update-kubeconfig --name <cluster>` (or your provider's command) and store its contents in GitLab as `KUBECONFIG_DATA`.
+3. Ensure Crossplane is already installed on the cluster referenced by `KUBECONFIG_DATA`.
 4. Trigger the pipeline. After the push stage completes, the `deploy_bcp` and `deploy_jcp` jobs apply the manifests under `crossplane-bcp/clusters/` using `kubectl`.
 
 

--- a/crossplane-bcp/README.md
+++ b/crossplane-bcp/README.md
@@ -58,6 +58,7 @@ kubectl config view --minify --raw > kubeconfig
 ```
 
 Copy the file's contents into the `KUBECONFIG_DATA` variable in GitLab before running the deploy jobs.
+Ensure Crossplane is already installed in the cluster referenced by this kubeconfig.
 
 ### Harbor Access
 


### PR DESCRIPTION
## Summary
- clarify kubeconfig retrieval in README
- mention Crossplane should already be installed in target cluster
- add same note in crossplane-bcp README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849991ede04832f89d310bb41b1f8e8