### PR TITLE
Fix xpkg artifacts and update deploy deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,12 @@ build_xpkgs:
     - crossplane xpkg build --name services.xpkg crossplane-bcp/build/services
     - crossplane xpkg build --name config-bundle.xpkg crossplane-bcp/config-bundle
     - crossplane xpkg build --name jcp-config-bundle.xpkg crossplane-bcp/jcp-config-bundle
+  artifacts:
+    paths:
+      - provider-configs.xpkg
+      - services.xpkg
+      - config-bundle.xpkg
+      - jcp-config-bundle.xpkg
 
 build_packages:
   stage: build
@@ -89,6 +95,7 @@ deploy_bcp:
   stage: deploy
   image: bitnami/kubectl:latest
   dependencies:
+    - build_xpkgs
     - build_packages
   script:
     - echo "$KUBECONFIG_DATA" > ${KUBECONFIG}


### PR DESCRIPTION
## Summary
- persist provider and service packages in the pipeline
- ensure `deploy_bcp` downloads packages from `build_xpkgs`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684995676fa0832f80c491f82d086bed