### PR TITLE
Expose IAM role parameters for EKS composition

### DIFF
--- a/crossplane-bcp/ARCHITECTURE.md
+++ b/crossplane-bcp/ARCHITECTURE.md
@@ -42,17 +42,14 @@ installations.
 ### AWS Prerequisites
 
 The EKS composition in `build/services/compositions/eks-composition.yaml`
-includes placeholder values for the cluster and node group IAM roles and the
-subnet IDs. Replace these with valid values from your AWS account before
-deploying the control plane:
+exposes parameters for IAM roles and subnet IDs so you can supply values from
+your AWS account when deploying the control plane:
 
-- `roleArn` must reference an IAM role with permissions for the EKS control
-  plane, for example `arn:aws:iam::123456789012:role/eks-control-plane`.
-- `nodeRoleArn` values should be IAM roles used by each NodeGroup,
-  such as `arn:aws:iam::123456789012:role/eks-node-role` for the BCP and
-  `arn:aws:iam::123456789012:role/eks-jcp-node-role` for the JCP.
-- `subnetIds` must list the actual subnet IDs where the nodes will run,
-  e.g. `subnet-0123456789abcdef0`.
+- `controlPlaneRoleArn` &mdash; IAM role used by the EKS control plane.
+- `nodeRoleArn` &mdash; IAM role for the BCP NodeGroup.
+- `nodeSubnetIds` &mdash; subnet IDs for the BCP nodes.
+- `jcpNodeRoleArn` &mdash; IAM role for the JCP NodeGroup.
+- `jcpSubnetIds` &mdash; subnet IDs for the JCP nodes.
 
-Specify the `instanceType` and `diskSize` parameters for each NodeGroup
-to match the recommended sizes above.
+Provide these parameters along with `instanceType` and `diskSize` to
+match the recommended sizes above.

--- a/crossplane-bcp/build/services/compositions/cluster-definition.yaml
+++ b/crossplane-bcp/build/services/compositions/cluster-definition.yaml
@@ -36,6 +36,20 @@ spec:
                         type: string
                       jcpDiskSize:
                         type: integer
+                      controlPlaneRoleArn:
+                        type: string
+                      nodeRoleArn:
+                        type: string
+                      nodeSubnetIds:
+                        type: array
+                        items:
+                          type: string
+                      jcpNodeRoleArn:
+                        type: string
+                      jcpSubnetIds:
+                        type: array
+                        items:
+                          type: string
                     required:
                       - region
                       - version

--- a/crossplane-bcp/build/services/compositions/eks-composition.yaml
+++ b/crossplane-bcp/build/services/compositions/eks-composition.yaml
@@ -17,7 +17,7 @@ spec:
           forProvider:
             region: us-east-1
             version: "1.29"
-            roleArn: arn:aws:iam::123456789012:role/eks-control-plane
+            roleArn: "" # patched from controlPlaneRoleArn parameter
             resourcesVpcConfig:
               endpointPublicAccess: true
         patches:
@@ -25,6 +25,8 @@ spec:
             toFieldPath: spec.forProvider.region
           - fromFieldPath: spec.parameters.version
             toFieldPath: spec.forProvider.version
+          - fromFieldPath: spec.parameters.controlPlaneRoleArn
+            toFieldPath: spec.forProvider.roleArn
     - name: nodegroup
       base:
         apiVersion: eks.aws.upbound.io/v1beta1
@@ -34,9 +36,8 @@ spec:
             region: us-east-1
             clusterNameSelector:
               matchControllerRef: true
-            nodeRoleArn: arn:aws:iam::123456789012:role/eks-node-role
-            subnetIds:
-              - subnet-0123456789abcdef0
+            nodeRoleArn: ""   # patched from nodeRoleArn parameter
+            subnetIds: []     # patched from nodeSubnetIds parameter
             instanceType: t3.medium # default instance type
             diskSize: 50            # default disk size in GiB
             scalingConfig:
@@ -46,6 +47,10 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.nodeRoleArn
+          toFieldPath: spec.forProvider.nodeRoleArn
+        - fromFieldPath: spec.parameters.nodeSubnetIds
+          toFieldPath: spec.forProvider.subnetIds
         - fromFieldPath: spec.parameters.instanceType
           toFieldPath: spec.forProvider.instanceType
         - fromFieldPath: spec.parameters.diskSize
@@ -59,9 +64,8 @@ spec:
             region: us-east-1
             clusterNameSelector:
               matchControllerRef: true
-            nodeRoleArn: arn:aws:iam::123456789012:role/eks-jcp-node-role
-            subnetIds:
-              - subnet-0123456789abcdef0
+            nodeRoleArn: ""   # patched from jcpNodeRoleArn parameter
+            subnetIds: []     # patched from jcpSubnetIds parameter
             instanceType: t3.large # default instance type for JCP
             diskSize: 100          # default disk size in GiB
             scalingConfig:
@@ -71,6 +75,10 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.jcpNodeRoleArn
+          toFieldPath: spec.forProvider.nodeRoleArn
+        - fromFieldPath: spec.parameters.jcpSubnetIds
+          toFieldPath: spec.forProvider.subnetIds
         - fromFieldPath: spec.parameters.jcpInstanceType
           toFieldPath: spec.forProvider.instanceType
         - fromFieldPath: spec.parameters.jcpDiskSize


### PR DESCRIPTION
## Summary
- parameterize EKS cluster IAM roles and subnet IDs
- include `instanceType` and `diskSize` patches
- document required parameters and recommended node sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849a0f89cb4832f92b643e0560d3a32