### PR TITLE
Add kubeconfig setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Refer to `crossplane-bcp/README.md` for detailed instructions on deploying the B
 The `.gitlab-ci.yml` pipeline builds, pushes and now deploys the Crossplane configuration. To execute the pipeline end-to-end:
 
 1. Set `DEV_REGISTRY` to the container registry where packages should be pushed. The default value in `.gitlab-ci.yml` is `registry.example.com/dev`, but you must replace this with the URL of your actual registry (GitLab registry, ECR, etc.) for the push stage to succeed.
-2. Retrieve the kubeconfig for the **target** cluster using `aws eks update-kubeconfig --name <cluster>` (or your provider's command) and store its contents in GitLab as `KUBECONFIG_DATA`.
-3. Ensure Crossplane is already installed on the cluster referenced by `KUBECONFIG_DATA`.
-4. Trigger the pipeline. After the push stage completes, the `deploy_bcp` and `deploy_jcp` jobs apply the manifests under `crossplane-bcp/clusters/` using `kubectl`.
+2. Retrieve the kubeconfig for the **target** cluster using your provider's CLI, for example:
+   ```bash
+   aws eks update-kubeconfig --name <cluster>
+   ```
+3. Paste the contents of the generated file into the GitLab CI variable `KUBECONFIG_DATA`.
+4. Ensure Crossplane is already installed on the cluster referenced by this kubeconfig.
+5. Trigger the pipeline. After the push stage completes, the `deploy_bcp` and `deploy_jcp` jobs apply the manifests under `crossplane-bcp/clusters/` using `kubectl`.
 
 
 ### Extracting the kubeconfig

--- a/crossplane-bcp/README.md
+++ b/crossplane-bcp/README.md
@@ -28,7 +28,14 @@ crossplane-bcp/
 The `.gitlab-ci.yml` file at the repo root packages these resources and pushes them to the container registry specified by `DEV_REGISTRY`.
 Optional jobs invoke the scripts in `scripts/` to destroy the BCP or JCP clusters when scheduled.
 
-The pipeline also contains a `deploy` stage. `deploy_bcp` installs the Base Control Plane by applying `clusters/bcp/crossplane.yaml`, then `deploy_jcp` installs the JCP using the manifests under `clusters/jcp/`. These jobs require the `KUBECONFIG_DATA` variable to be set with credentials for the target Kubernetes cluster. Ensure Crossplane is already installed on that cluster.
+The pipeline also contains a `deploy` stage. `deploy_bcp` installs the Base Control Plane by applying `clusters/bcp/crossplane.yaml`, then `deploy_jcp` installs the JCP using the manifests under `clusters/jcp/`.
+These jobs require the `KUBECONFIG_DATA` variable to be set with credentials for the target Kubernetes cluster.
+Retrieve the kubeconfig using your provider's CLI, for example:
+```bash
+aws eks update-kubeconfig --name <cluster>
+```
+Paste the file's contents into the GitLab CI variable `KUBECONFIG_DATA`.
+Ensure Crossplane is already installed on that cluster before triggering the deploy jobs.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for additional details about execution environments and trust zones.
 


### PR DESCRIPTION
## Summary
- clarify how to retrieve kubeconfig for the target cluster
- document storing the kubeconfig in GitLab CI and verifying Crossplane is installed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849b055a5c8832fa35a21646f5b806e