### PR TITLE
Remove duplicate Crossplane build commands

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,30 +14,23 @@ build_xpkgs:
   script:
     - crossplane xpkg build --name provider-configs.xpkg crossplane-bcp/build/providerConfigs
     - crossplane xpkg build --name services.xpkg crossplane-bcp/build/services
-    - crossplane xpkg build --name config-bundle.xpkg crossplane-bcp/config-bundle
     - crossplane xpkg build --name jcp-config-bundle.xpkg crossplane-bcp/jcp-config-bundle
   artifacts:
     paths:
       - provider-configs.xpkg
       - services.xpkg
-      - config-bundle.xpkg
       - jcp-config-bundle.xpkg
 
 build_packages:
   stage: build
   image: crossplane/crossplane-cli:latest
   script:
-    - crossplane xpkg build --name provider-configs.xpkg crossplane-bcp/build/providerConfigs
-    - crossplane xpkg build --name services.xpkg crossplane-bcp/build/services
     - crossplane xpkg build --name config-bundle.xpkg crossplane-bcp/config-bundle
     - crossplane xpkg build --name function-object-reader.xpkg crossplane-bcp/functions/object-reader
     - crossplane xpkg build --name function-git-reader.xpkg crossplane-bcp/functions/git-reader
   artifacts:
     paths:
-      - provider-configs.xpkg
-      - services.xpkg
       - config-bundle.xpkg
-      - jcp-config-bundle.xpkg
       - function-object-reader.xpkg
       - function-git-reader.xpkg
 


### PR DESCRIPTION
## Summary
- streamline xpkg build jobs so packages are only built once

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849bb860b40832f93d207d69014437a