### PR TITLE
Parameterize registry in base Helm chart

### DIFF
--- a/crossplane-bcp/helm/helm-base/values.yaml
+++ b/crossplane-bcp/helm/helm-base/values.yaml
@@ -1,1 +1,1 @@
-
+registry: ${DEV_REGISTRY}


### PR DESCRIPTION
## Summary
- set `registry` to use `$DEV_REGISTRY` in helm-base chart

## Testing
- `helm version --short` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bc63b094832f82b3408973f1e146