### PR TITLE
Deploy Crossplane configs from local files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,10 @@
 stages:
   - build
-  - push
+  - deploy
   - destroy
 
 variables:
-  DEV_REGISTRY: "registry.example.com/dev"
+  KUBECONFIG: "$CI_PROJECT_DIR/kubeconfig"
 
 build_xpkgs:
   stage: build
@@ -42,45 +42,40 @@ build_helm:
       - helm-base-0.1.0.tgz
       - helm-jcrs-jcp-0.1.0.tgz
 
-push_xpkgs:
-  stage: push
-  image: crossplane/crossplane-cli:latest
-  script:
-    - crossplane xpkg push provider-configs.xpkg ${DEV_REGISTRY}/provider-configs:latest
-    - crossplane xpkg push services.xpkg ${DEV_REGISTRY}/bcp-services:latest
-    - crossplane xpkg push config-bundle.xpkg ${DEV_REGISTRY}/bcp-config-bundle:latest
-    - crossplane xpkg push jcp-config-bundle.xpkg ${DEV_REGISTRY}/jcp-config-bundle:latest
-    - crossplane xpkg push function-object-reader.xpkg ${DEV_REGISTRY}/function-object-reader:latest
-    - crossplane xpkg push function-git-reader.xpkg ${DEV_REGISTRY}/function-git-reader:latest
-
-push_helm:
-  stage: push
-  image: alpine/helm:3.8.2
-  script:
-    - helm push helm-base-0.1.0.tgz oci://${DEV_REGISTRY}
-    - helm push helm-jcrs-jcp-0.1.0.tgz oci://${DEV_REGISTRY}
-
 destroy_bcp:
   stage: destroy
   image: crossplane/crossplane-cli:latest
   script:
-    - crossplane xpkg yank ${DEV_REGISTRY}/bcp-config-bundle:latest || true
     - ./crossplane-bcp/scripts/destroy_bcp.sh
 
 destroy_jcp:
   stage: destroy
   image: crossplane/crossplane-cli:latest
   script:
-    - crossplane xpkg yank ${DEV_REGISTRY}/jcp-config-bundle:latest || true
     - ./crossplane-bcp/scripts/destroy_jcp.sh
-      - config-bundle.xpkg
-      - function-object-reader.xpkg
-      - function-git-reader.xpkg
 
-push_packages:
-  stage: push
+deploy_bcp:
+  stage: deploy
   image: crossplane/crossplane-cli:latest
   script:
-    - crossplane xpkg push config-bundle.xpkg ${DEV_REGISTRY}/bcp-config-bundle:latest
-    - crossplane xpkg push function-object-reader.xpkg ${DEV_REGISTRY}/function-object-reader:latest
-    - crossplane xpkg push function-git-reader.xpkg ${DEV_REGISTRY}/function-git-reader:latest
+    - echo "$KUBECONFIG_DATA" > ${KUBECONFIG}
+    - kubectl crossplane install configuration -f provider-configs.xpkg
+    - kubectl crossplane install configuration -f services.xpkg
+    - kubectl crossplane install configuration -f config-bundle.xpkg
+
+deploy_jcp:
+  stage: deploy
+  image: crossplane/crossplane-cli:latest
+  needs: ["deploy_bcp"]
+  script:
+    - echo "$KUBECONFIG_DATA" > ${KUBECONFIG}
+    - kubectl crossplane install configuration -f jcp-config-bundle.xpkg
+
+apply_clusterclaim:
+  stage: deploy
+  image: bitnami/kubectl:latest
+  needs: ["deploy_jcp"]
+  script:
+    - echo "$KUBECONFIG_DATA" > ${KUBECONFIG}
+    - kubectl apply -f crossplane-bcp/clusters/jcp/clusterclaim.yaml
+

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ packer-win10_1909.json - Packer definitions for building Windows images
 ```
 
 Refer to `crossplane-bcp/README.md` for detailed instructions on deploying the BCP and JCP using Crossplane. The original blog post on automating WVD with Azure DevOps can be found [here](https://bit.ly/2Qj8kfe).
+
+## Running the Pipeline
+
+The `.gitlab-ci.yml` pipeline builds and then deploys the Crossplane configuration directly from the generated `.xpkg` files. To run it end-to-end:
+
+1. Provide a `KUBECONFIG_DATA` variable in GitLab CI containing credentials for the target Kubernetes cluster.
+2. Trigger the pipeline. After the build stage completes, the `deploy_bcp`, `deploy_jcp`, and `apply_clusterclaim` jobs install each package using `kubectl crossplane install` and then apply the `ClusterClaim` manifest.
+   Edit `crossplane-bcp/clusters/jcp/clusterclaim.yaml` if your environment requires different region, Kubernetes version, or node sizing before running the pipeline.
+

--- a/crossplane-bcp/ARCHITECTURE.md
+++ b/crossplane-bcp/ARCHITECTURE.md
@@ -29,3 +29,11 @@ The Base Control Plane (BCP) is a single‑node installation used to bootstrap t
 ### JCP Responsibilities
 - Provision workload EKS clusters via Crossplane.
 - Manage application deployments via ArgoCD with charts stored in Harbor.
+
+### Recommended Node Sizing
+The BCP cluster uses a small NodeGroup to bootstrap the first JCP. A `t3.medium`
+instance type with a 20GiB disk is sufficient for this control plane.
+
+JCP workload clusters run ArgoCD, Harbor, Keycloak, and other services. These
+clusters should use at least three `t3.large` worker nodes with 40GiB disks to
+provide adequate capacity and redundancy for production deployments.

--- a/crossplane-bcp/README.md
+++ b/crossplane-bcp/README.md
@@ -25,8 +25,12 @@ crossplane-bcp/
 └── README.md
 ```
 
-The `.gitlab-ci.yml` file at the repo root packages these resources and pushes them to the container registry specified by `DEV_REGISTRY`.
-Optional jobs invoke the scripts in `scripts/` to destroy the BCP or JCP clusters when scheduled.
+The `.gitlab-ci.yml` file at the repo root builds the required packages and then installs them directly from the generated `.xpkg` files. Optional jobs invoke the scripts in `scripts/` to destroy the BCP or JCP clusters when scheduled.
+
+The pipeline contains a `deploy` stage. `deploy_bcp` installs the Base Control Plane using `kubectl crossplane install` for each package. `deploy_jcp` installs the JCP bundle in the same way, and `apply_clusterclaim` provisions an EKS cluster from `clusters/jcp/clusterclaim.yaml`. These jobs require the `KUBECONFIG_DATA` variable to be set with credentials for the target Kubernetes cluster.
+
+The ClusterClaim manifest also defines NodeGroup sizing parameters. Adjust the `instanceType`, `diskSize`, and `desiredSize` values to suit your environment before running the pipeline.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for additional details about execution environments and trust zones.
+
 

--- a/crossplane-bcp/build/services/compositions/eks-composition.yaml
+++ b/crossplane-bcp/build/services/compositions/eks-composition.yaml
@@ -32,6 +32,9 @@ spec:
         spec:
           forProvider:
             region: us-east-1
+            instanceTypes:
+              - t3.medium
+            diskSize: 20
             clusterNameSelector:
               matchControllerRef: true
             nodeRoleArn: example
@@ -44,3 +47,13 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.instanceType
+          toFieldPath: spec.forProvider.instanceTypes[0]
+        - fromFieldPath: spec.parameters.diskSize
+          toFieldPath: spec.forProvider.diskSize
+        - fromFieldPath: spec.parameters.desiredSize
+          toFieldPath: spec.forProvider.scalingConfig.desiredSize
+        - fromFieldPath: spec.parameters.maxSize
+          toFieldPath: spec.forProvider.scalingConfig.maxSize
+        - fromFieldPath: spec.parameters.minSize
+          toFieldPath: spec.forProvider.scalingConfig.minSize

--- a/crossplane-bcp/clusters/bcp/crossplane.yaml
+++ b/crossplane-bcp/clusters/bcp/crossplane.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: bcp
 spec:
-  package: ${DEV_REGISTRY}/bcp-config-bundle:latest
+  package: bcp-config-bundle:latest

--- a/crossplane-bcp/clusters/jcp/clusterclaim.yaml
+++ b/crossplane-bcp/clusters/jcp/clusterclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: compute.jne.rd/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: my-cluster
+spec:
+  parameters:
+    region: us-east-1
+    version: "1.29"
+    instanceType: t3.large
+    diskSize: 40
+    desiredSize: 3
+    maxSize: 3
+    minSize: 3

--- a/crossplane-bcp/clusters/jcp/crossplane.yaml
+++ b/crossplane-bcp/clusters/jcp/crossplane.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: jcp
 spec:
-  package: ${DEV_REGISTRY}/jcp-config-bundle:latest
+  package: jcp-config-bundle:latest

--- a/crossplane-bcp/scripts/destroy_bcp.sh
+++ b/crossplane-bcp/scripts/destroy_bcp.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 # Teardown BCP cluster resources
-kubectl delete configuration jcp --ignore-not-found
 kubectl delete configuration bcp --ignore-not-found


### PR DESCRIPTION
## Summary
- skip the registry push stage
- install packages directly from built `.xpkg` files
- update cluster manifests and docs for local installs
- keep BCP teardown from deleting JCP config
- document and parameterize node sizing for BCP and JCP clusters

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68435c243db8832fb2073a24fcec2407