### PR TITLE
Add scaling fields to cluster definition

### DIFF
--- a/crossplane-bcp/build/services/compositions/cluster-definition.yaml
+++ b/crossplane-bcp/build/services/compositions/cluster-definition.yaml
@@ -32,6 +32,12 @@ spec:
                         type: string
                       diskSize:
                         type: integer
+                      desiredSize:
+                        type: integer
+                      maxSize:
+                        type: integer
+                      minSize:
+                        type: integer
                       jcpInstanceType:
                         type: string
                       jcpDiskSize:
@@ -53,6 +59,11 @@ spec:
                     required:
                       - region
                       - version
+                      - instanceType
+                      - diskSize
+                      - desiredSize
+                      - maxSize
+                      - minSize
                 required:
                   - parameters
             required:


### PR DESCRIPTION
## Summary
- expose NodeGroup sizing parameters in the `cluster-definition.yaml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b0198d9f8832fbf867ba8791eabec