### PR TITLE
Update crossplane values for air-gapped install

### DIFF
--- a/crossplane-bcp/helm/helm-base/values.yaml
+++ b/crossplane-bcp/helm/helm-base/values.yaml
@@ -1,1 +1,2 @@
-registry: ${DEV_REGISTRY}
+# Local registry path used for air-gapped installations
+registry: /path/to/local/registry


### PR DESCRIPTION
## Summary
- update registry path in helm values to point to local air-gapped registry

## Testing
- `grep -n registry -R crossplane-bcp/helm/helm-base/values.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684b039aed0c832fb3c7a2127f0f90a9